### PR TITLE
test-case-save-db-verify

### DIFF
--- a/tests/browser-tests/testWebhookWhatsapp.js
+++ b/tests/browser-tests/testWebhookWhatsapp.js
@@ -1,10 +1,18 @@
 const { expect } = require('chai');
 const testBase = require('./testBase.js');
 
+// Function to generate a unique ProfileName
+function generateUniqueProfileName() {
+  return `ProfileName-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+}
+
 it("If account ssid different then message should get saved to a file but shouldn't get stored in database", async function() {
   console.log('Testing ' + __filename);
   try {
     console.log("send message to /webhook/whatsapp");
+    // Generate a unique ProfileName
+    const uniqueProfileName = generateUniqueProfileName();
+
     const response = await fetch('http://node:8080/webhook/whatsapp', {
       method: 'POST',
       headers: {
@@ -14,7 +22,7 @@ it("If account ssid different then message should get saved to a file but should
         AccountSid: 'testUser',
         SmsMessageSid: 'SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
         NumMedia: '0',
-        ProfileName: 'Profile Name',
+        ProfileName: uniqueProfileName,
         MessageType: 'text',
         SmsSid: 'SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
         WaId: '1234567890',
@@ -39,6 +47,12 @@ it("If account ssid different then message should get saved to a file but should
     console.log("Confirm that Message saved to file");
     expect(content).to.include('Test message');
 
+    console.log("Confirm that Message NOT saved to database");
+    // Query for the document by the non-existing ProfileName
+    const result = await app.c("webhookWhatsApp").collection().findOne({ ProfileName: uniqueProfileName });
+    // Check that the document does not exist
+    expect(result).to.be.null;
+
     console.log("Ensuring that account ssid id is different then we should get 403");
     // Assert status and message
     expect(response.status).to.equal(403);
@@ -55,6 +69,9 @@ it("If account ssid same as message then message should get saved to a file and 
 
   console.log('Testing ' + __filename);
   try {
+    // Generate a unique ProfileName
+    const uniqueProfileName = generateUniqueProfileName();
+
     console.log("send message to /webhook/whatsapp");
     const response = await fetch('http://node:8080/webhook/whatsapp', {
       method: 'POST',
@@ -65,7 +82,7 @@ it("If account ssid same as message then message should get saved to a file and 
         AccountSid: twilioUser,
         SmsMessageSid: 'SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
         NumMedia: '0',
-        ProfileName: 'Profile Name',
+        ProfileName: uniqueProfileName,
         MessageType: 'text',
         SmsSid: 'SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
         WaId: '1234567890',
@@ -92,6 +109,12 @@ it("If account ssid same as message then message should get saved to a file and 
     console.log("Ensuring that account ssid id is same then we should get 200");
     // Assert status and message
     expect(response.status).to.equal(200);
+
+    console.log("Confirm that Message saved to database");
+    const result = await app.c("webhookWhatsApp").collection().findOne({ ProfileName: uniqueProfileName });
+    expect(result).to.include(uniqueProfileName);
+    // Clean up by removing the document after the test
+    await app.c("webhookWhatsApp").collection().deleteOne({ ProfileName: uniqueProfileName });
   }
   catch (error) {
     console.log(error);
@@ -104,6 +127,9 @@ it("If account ssid undefined then message shouldn't stored in db", async functi
   console.log('Testing ' + __filename);
   try {
     console.log("send message to /webhook/whatsapp");
+    // Generate a unique ProfileName
+    const uniqueProfileName = generateUniqueProfileName();
+
     const response = await fetch('http://node:8080/webhook/whatsapp', {
       method: 'POST',
       headers: {
@@ -112,7 +138,7 @@ it("If account ssid undefined then message shouldn't stored in db", async functi
       body: JSON.stringify({
         SmsMessageSid: 'SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
         NumMedia: '0',
-        ProfileName: 'Profile Name',
+        ProfileName: uniqueProfileName,
         MessageType: 'text',
         SmsSid: 'SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
         WaId: '1234567890',
@@ -126,6 +152,12 @@ it("If account ssid undefined then message shouldn't stored in db", async functi
         ApiVersion: '2010-04-01'
       })
     });
+
+    console.log("Confirm that Message NOT saved to database");
+    // Query for the document by the non-existing ProfileName
+    const result = await app.c("webhookWhatsApp").collection().findOne({ ProfileName: uniqueProfileName });
+    // Check that the document does not exist
+    expect(result).to.be.null;
 
     console.log("Ensuring account ssid is undefined then we should get 403");
     // Assert status and message


### PR DESCRIPTION
ReferenceError: app is not defined
    at Context.<anonymous> (/app/test/testWebhookWhatsapp.js:114:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)


In whatsapp-communication/tests/browser-tests/testWebhookWhatsapp.js  I want to to verify that if data saved to database   in test cases.  I want to know how to access  app object reference in tests.

After that I will fix below issues.
tests/browser-tests/testWebhookWhatsapp.js: line 54, col 26, Expected an assignment or function call and instead saw an expression.
tests/browser-tests/testWebhookWhatsapp.js: line 160, col 26, Expected an assignment or function call and instead saw an expression.

